### PR TITLE
fix(deps): upgrade click to 8.4.2 to resolve PYSEC-2026-2132

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pydantic-settings>=2.14.2",
     "pyyaml>=6.0.3",
     "typer>=0.24.1",
+    "click>=8.3.3",
     "rich>=14.3.3",
     "python-dotenv>=1.2.2",
     "anthropic>=0.86.0",

--- a/uv.lock
+++ b/uv.lock
@@ -431,14 +431,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -450,6 +450,7 @@ dependencies = [
     { name = "anyio" },
     { name = "azure-monitor-opentelemetry-exporter" },
     { name = "claude-agent-sdk" },
+    { name = "click" },
     { name = "jmespath" },
     { name = "jsonschema" },
     { name = "opentelemetry-sdk" },
@@ -495,6 +496,7 @@ requires-dist = [
     { name = "azure-monitor-opentelemetry-exporter", specifier = ">=1.0.0b30,<1.1.0" },
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.9.4" },
     { name = "claude-agent-sdk", specifier = ">=0.2.82" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "google-antigravity", marker = "extra == 'antigravity'", specifier = "==0.1.5" },
     { name = "jmespath", specifier = ">=1.1.0" },
     { name = "jsonschema", specifier = ">=4.26.0" },


### PR DESCRIPTION
## Summary

- `click 8.3.1` has a command injection vulnerability in `click.edit()` (PYSEC-2026-2132, fixed in 8.3.3)
- The CVE appeared in the vulnerability database today, breaking the `pip-audit` step in the Quality Gate for all open PRs
- Pins `click>=8.3.3` as an explicit dependency so `uv` resolves to `8.4.2`

## Notes

`click` is a transitive dep via `typer` — this adds a direct lower-bound to force the upgrade. Unblocks PR #19 and any other PRs open against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)