### PR TITLE
fix(codex): create CODEX_HOME before pinning it in the app-server env

### DIFF
--- a/src/coder_eval/agents/codex_agent.py
+++ b/src/coder_eval/agents/codex_agent.py
@@ -1089,7 +1089,13 @@ class CodexAgent(Agent[CodexAgentConfig]):
             # shell), which ignores HOME for dotfile selection when it is set.
             env["HOME"] = str(self._login_shell_home)
             env["ZDOTDIR"] = str(self._login_shell_home)
-            env["CODEX_HOME"] = str(self._codex_home())
+            # The binary hard-errors on an explicitly set CODEX_HOME that does
+            # not exist (unset, it materializes the ~/.codex default itself) —
+            # hosts that auth via CODEX_API_KEY never ran `codex login`, so
+            # the dir may not exist yet. Create it before pinning.
+            codex_home = self._codex_home()
+            codex_home.mkdir(parents=True, exist_ok=True)
+            env["CODEX_HOME"] = str(codex_home)
         return env if env else None
 
     @staticmethod

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1755,6 +1755,20 @@ class TestLoginShellMockPathHome:
         # harness reads the same _codex_home() for sub-agent rollout recovery.
         assert env["CODEX_HOME"] == str(agent._codex_home())
 
+    def test_build_codex_env_creates_missing_codex_home(self, monkeypatch, tmp_path):
+        """The codex binary hard-errors on an explicitly set CODEX_HOME that
+        does not exist (unset, it materializes the ~/.codex default itself).
+        Runners that auth via CODEX_API_KEY never ran ``codex login``, so the
+        dir may not exist — pinning it must create it first."""
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path / "state" / ".codex"))
+        agent = self._agent_with_prepend(["/sandbox/mocks"])
+        agent._login_shell_home = tmp_path / "login-home"
+
+        env = agent._build_codex_env()
+        assert env is not None
+        assert Path(env["CODEX_HOME"]).is_dir()
+
     def test_build_codex_env_without_login_home_leaves_home_alone(self, monkeypatch):
         monkeypatch.setenv("CODEX_API_KEY", "k")
         agent = CodexAgent(parse_agent_config(type=AgentKind.CODEX))


### PR DESCRIPTION
## Problem

Every codex run with mocks configured on POSIX fails at startup since #26:

```
Failed to initialize Codex client: Codex process closed stdout. stderr_tail=WARNING: proceeding, even though we could not create PATH aliases: CODEX_HOME points to "/root/.codex", but that path does not exist
Error: CODEX_HOME points to "/root/.codex", but that path does not exist
```

#26 pins `CODEX_HOME` in the app-server env (so codex state does not follow the redirected login-shell `HOME`). The codex binary treats an explicitly set `CODEX_HOME` strictly: it hard-errors when the path does not exist, whereas with the env var unset it materializes the `~/.codex` default itself. On runners that auth via `CODEX_API_KEY` (never ran `codex login`), `~/.codex` does not exist, so the app-server dies at startup. Dev machines have `~/.codex`, unit tests pointed `CODEX_HOME` at existing tmp dirs, and Windows never enters the login-shell path - which is why nothing caught it.

## Fix

Create the resolved dir (`mkdir(parents=True, exist_ok=True)`) before pinning it - mirrors the binary's own default-dir behavior, idempotent across `start()` retries.

## Validation

- New regression test `test_build_codex_env_creates_missing_codex_home` (fails on main, passes here).
- Reproduced against the bundled codex-cli 0.144.4 binary: `codex app-server` with `CODEX_HOME` pointing at a nonexistent dir exits 1 with the exact error above; with the dir pre-created it starts cleanly.
- Full suite: 3342 passed (2 pre-existing Windows symlink-privilege failures in `test_sandbox.py`, also failing on main); ruff format/check and pyright clean.