### PR TITLE
docs: add Website badge and point PyPI Homepage at coder-eval.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Coder Eval — evaluate & benchmark AI coding agents and Claude Code skills
 
 [![PyPI](https://img.shields.io/pypi/v/coder-eval.svg)](https://pypi.org/project/coder-eval/)
+[![Website](https://img.shields.io/badge/website-coder--eval.com-1f6feb.svg)](https://coder-eval.com)
 [![Docs](https://img.shields.io/badge/docs-uipath.github.io%2Fcoder__eval-1f6feb.svg)](https://uipath.github.io/coder_eval/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/UiPath/coder_eval"
+Homepage = "https://coder-eval.com"
 Repository = "https://github.com/UiPath/coder_eval"
 Documentation = "https://github.com/UiPath/coder_eval/tree/main/docs"
 Issues = "https://github.com/UiPath/coder_eval/issues"


### PR DESCRIPTION
Adds a Website badge to the README next to the existing Docs badge, and repoints the `pyproject.toml` `Homepage` URL at the live site so the PyPI sidebar links there instead of the repo (`Repository` still covers GitHub).

## Changes

- `README.md:4` — new Website badge (verified `https://coder-eval.com` returns 200)
- `pyproject.toml:54` — `Homepage` moved from the GitHub repo to `https://coder-eval.com`

## Note (not addressed here)

The existing **Docs badge is broken**: `https://uipath.github.io/coder_eval/` returns **404**, despite `mkdocs.yml` and `.github/workflows/docs.yml` existing — GitHub Pages is likely not enabled on the repo, or the docs workflow hasn't published successfully. For that reason `Documentation` in `pyproject.toml` was left pointing at `tree/main/docs` rather than the (404ing) Pages URL. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)