### PR TITLE
ci: enforce Conventional Commits locally via commit-msg hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,8 @@
 # templates/flow-v2-shared/sync-tools.sh.
 exclude: ^templates/flow-v2-shared/tools/
 
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   # Ruff for formatting and linting
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -41,3 +43,12 @@ repos:
         types: [python]
         pass_filenames: false
         stages: [manual]  # Run only with: pre-commit run --hook-stage manual pyright
+
+      # Mirrors .github/workflows/conventional-commits.yml's commit-message check.
+      # (The PR-title half of that workflow can't be checked locally — GitHub
+      # only knows the PR title once the PR exists.)
+      - id: conventional-commit-msg
+        name: conventional commit message
+        entry: scripts/check_commit_msg.sh
+        language: script
+        stages: [commit-msg]

--- a/scripts/check_commit_msg.sh
+++ b/scripts/check_commit_msg.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Enforces Conventional Commits locally, mirroring .github/workflows/conventional-commits.yml.
+set -euo pipefail
+
+MSG_FILE="$1"
+MSG="$(head -n1 "$MSG_FILE")"
+PATTERN='^(feat|fix|refactor|docs|style|test|chore|perf|ci|build|revert)(\([a-z0-9._/-]+\))?(!)?: .+'
+
+if echo "$MSG" | grep -Eq '^Merge (pull request|branch|remote-tracking)'; then
+  exit 0
+fi
+
+if ! echo "$MSG" | grep -Eq "$PATTERN"; then
+  echo "ERROR: commit message does not follow Conventional Commits."
+  echo "  Got:      $MSG"
+  echo "  Expected: <type>[optional scope]: <description>"
+  echo "  Types:    feat | fix | refactor | docs | style | test | chore | perf | ci | build | revert"
+  echo "  Examples: feat(sandbox): add preservation mode"
+  echo "            fix: handle empty dataset gracefully"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds a `commit-msg` pre-commit hook (`scripts/check_commit_msg.sh`) that mirrors the regex in `.github/workflows/conventional-commits.yml`, rejecting non-conventional commit messages locally before push/CI.
- Wires `default_install_hook_types: [pre-commit, commit-msg]` into `.pre-commit-config.yaml` so `make install` / `pre-commit install` sets up both hook types automatically for everyone.

Context: https://github.com/UiPath/coder_eval/actions/runs/30309413197/job/90121301720?pr=58 failed because the PR title/commit message wasn't Conventional-Commits-formatted. The PR-title half of that CI check can't be replicated locally (GitHub only knows the title once the PR exists), but the commit-message half can — and in practice, for single-commit PRs on a squash-merge repo, GitHub defaults the PR title to the commit subject, so keeping commit messages conventional keeps PR titles conventional too.

## Test plan
- [x] `uv run pytest -q` — 3741 passed, 10 skipped
- [x] Manually verified the hook fails on the exact bad message from the linked CI run and passes on a conventional one