### PR TITLE
chore(action): fix Marketplace listing name and add author

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,12 @@
-name: coder-eval
+# `name` is the GitHub Marketplace listing title and must be globally unique
+# across Marketplace actions, users, AND organizations. `coder-eval` is taken by
+# an unrelated squatted org (github.com/coder-eval), so the listing uses the
+# underscored repo name instead. This value is display-only: consumers reference
+# the action by repo path (`uses: UiPath/coder_eval@v0`), never by this name.
+name: coder_eval
+# Matches the authorship the project already declares in pyproject.toml
+# (`authors = [{ name = "UiPath", ... }]`) and NOTICE (`© 2026 UiPath`).
+author: UiPath
 description: Run coder-eval evaluation tasks as a CI gate, with JUnit XML output and a job-summary report.
 branding:
   icon: check-circle


### PR DESCRIPTION
Unblocks publishing the composite action to the GitHub Actions Marketplace.

## Why

Publishing `action.yml` to the Marketplace fails with:

> coder-eval - Name must be unique. Cannot match an existing action, user or organization name.

The Marketplace `name` must be globally unique across actions, **users, and organizations** — not just actions. [`github.com/coder-eval`](https://github.com/coder-eval) is an unrelated organization (created 2023-12-04, 1 public repo, no display name) squatting the name, so `name: coder-eval` can never be published as-is.

This was the last blocker on the listing. The prerequisite that previously blocked it — zero published Releases — was cleared by v0.9.0–v0.9.3.

## What changed

- `name: coder-eval` → `name: coder_eval`. Verified free as a Marketplace slug **and** as a GitHub user/org name.
- `author: UiPath` added — Marketplace surfaces it on the listing and it was previously absent. Matches the authorship the project already declares in `pyproject.toml` (`authors = [{ name = "UiPath", ... }]`) and `NOTICE` (`© 2026 UiPath`), and the repo owner that Marketplace derives “By UiPath” from.
- Comments recording *why* each value is what it is, so a future cleanup does not silently re-break the publish.

## Not a breaking change

`name` is **display-only**. Consumers reference the action by repo path:

```yaml
- uses: UiPath/coder_eval@v0
```

That path is unaffected. I searched the repo for Marketplace listing URLs (`marketplace/actions/…`) — there are none — and no README badge or doc names the action, so **no docs, tutorials, or workflow examples need updating**. Deliberately *not* touched: `coder-eval` is also the CLI command (`coder-eval run`) and the PyPI package (`pip install coder-eval`), neither of which changes.

## Follow-up required after merge

Merging alone does not make the new name live. `v0` is force-moved to a release by `release.yml`, not by a merge to `main`, so `@v0` will keep serving `name: coder-eval` until a release is cut. Sequence:

1. Merge this PR.
2. Let `release.yml` cut **0.9.4**.
3. Publish to Marketplace **from the 0.9.4 release** (a manual, one-time web-UI step — `gh release create` cannot tick the checkbox; every subsequent release then lists automatically).

If GitHub normalizes `_` → `-` in that uniqueness check, `coder_eval` will be rejected against the same squatted org. `coder-eval-ci-gate` is verified free as the fallback.

## Verification

- `action.yml` parses; `name`, `author`, `description`, `branding`, `runs.using: composite`, all 10 inputs and both outputs (`run-dir`, `junit-path`) intact.
- Names checked against both `github.com/<name>` and `github.com/marketplace/actions/<name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)