### PR TITLE
ci: bump gh-action-pypi-publish to v1.14.2 to accept Metadata-Version 2.5

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -98,7 +98,7 @@ jobs:
         run: uv build
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           # Trusted Publisher is configured on test.pypi.org for this repo +
           # workflow (publish-testpypi.yml) + environment (testpypi); no

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,7 +383,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           # Trusted Publisher is configured on pypi.org for this repo +
           # workflow (release.yml) + environment (pypi); no password needed.


### PR DESCRIPTION
## Problem

Release run [32174441035](https://github.com/UiPath/coder_eval/actions/runs/32174441035) (dispatched `bump=minor` from `636e87d5`) stamped and tagged **v0.10.0** but failed in **Publish to PyPI**:

```
Checking dist/coder_eval-0.10.0-py3-none-any.whl: ERROR InvalidDistribution:
Invalid distribution metadata: '2.5' is not a valid metadata version
```

The wheel is built by `uv build` with an unpinned build backend; between v0.9.6 (08-11, published fine) and today the backend started emitting `Metadata-Version: 2.5`. The publish action is pinned at v1.13.0, whose bundled twine predates metadata 2.5 and rejects the file before upload. Because the action is pinned by SHA, re-running the failed job reproduces the failure — the pin itself must move.

## Fix

Bump `pypa/gh-action-pypi-publish` from `ed0c5393` (v1.13.0) to `dc37677b` (**v1.14.2**, 2026-07-29), whose twine accepts Metadata-Version 2.5. Both pin sites move: `release.yml` and `publish-testpypi.yml` (the TestPyPI path would fail identically on the next prerelease).

## State + recovery

- `main` already carries `chore(release): 0.10.0 [skip ci]` and tag `v0.10.0`; PyPI has no 0.10.0 wheel and no GitHub Release was cut (the promote job was skipped, by design — a Release must not announce a version that is not on PyPI).
- After this merges, a fresh dispatch (`bump=patch`) cuts **v0.10.1** cleanly; v0.10.0 remains a tag-only version, noted in the changelog by the next release's notes.
- No historical run, consumer pin, or published artifact is mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVJhcHfkcKZEdj2ivLXcbJ