### PR TITLE
ci: exclude attestation sidecars from the PyPI artifact-identity assert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,7 +447,16 @@ jobs:
               sys.exit(0)
 
           remote = {u["filename"]: (u.get("digests") or {}).get("sha256") for u in payload.get("urls") or []}
-          local = sorted(p for p in pathlib.Path("dist").iterdir() if p.is_file())
+          # gh-action-pypi-publish v1.14+ writes `<dist>.publish.attestation`
+          # sidecars into packages-dir before upload. PyPI serves attestations
+          # via the integrity API, never as distribution files, so the sidecars
+          # must not enter the set-equality comparison below -- with them, this
+          # assert fails on every release even when the publish is complete and
+          # attested (observed on the v0.10.1 run).
+          local = sorted(
+              p for p in pathlib.Path("dist").iterdir()
+              if p.is_file() and not p.name.endswith(".publish.attestation")
+          )
           if not local:
               print("::error::no files in dist/ to compare -- the download-artifact step produced nothing")
               sys.exit(1)


### PR DESCRIPTION
## Problem

Release run [32177134404](https://github.com/UiPath/coder_eval/actions/runs/32177134404) (v0.10.1, dispatched after #123) published successfully — both distributions are served by PyPI with matching sha256, and both have provenance bundles on the integrity API (`/integrity/coder-eval/0.10.1/<file>/provenance` → HTTP 200, 1 bundle each). Yet **Assert PyPI serves this run's artifacts** failed twice (initial run and the `skip-existing` re-run):

```
coder_eval-0.10.1-py3-none-any.whl.publish.attestation: not present on PyPI for 0.10.1;
coder_eval-0.10.1.tar.gz.publish.attestation: not present on PyPI for 0.10.1
```

Cause: `gh-action-pypi-publish` v1.14+ (pinned by #123) writes `<dist>.publish.attestation` sidecars into `packages-dir` before upload. The assert builds its expected set from `dist/` contents, and PyPI never serves attestations as distribution files (they live behind the integrity API) — so the sidecars fail the set comparison on every future release, even a perfect one.

## Fix

Filter `*.publish.attestation` out of the local set. The distribution set-equality check — including its planted-extra-wheel direction — is unchanged. (A follow-up could additionally assert provenance presence via the integrity API; deliberately not bundled here to keep the recovery unblocking minimal.)

## State

v0.10.1 is complete and attested on PyPI (project latest) but its `promote` job (GitHub Release + major-tag move) was skipped by the failing assert. Re-runs reuse the original workflow snapshot, so this fix cannot rescue run 32177134404 itself — recovery options are in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVJhcHfkcKZEdj2ivLXcbJ