### PR TITLE
fix(docker): expand ~ and $VAR in extra_mounts destinations

### DIFF
--- a/src/coder_eval/isolation/docker_runner.py
+++ b/src/coder_eval/isolation/docker_runner.py
@@ -327,12 +327,15 @@ def _validate_extra_mount(spec: str) -> str:
     # Expanded before the absolute-path check: that is the point.
     expanded_src = os.path.expandvars(os.path.expanduser(src))
     dst = os.path.expandvars(os.path.expanduser(raw_dst))
+    # A variable whose value carries a ':' would add fields to the spec rebuilt
+    # at the bottom, silently moving the destination or widening the mode.
+    # The drive prefix is excluded: its colon is legitimate and already split off.
+    if ":" in dst or ":" in expanded_src[len(head) :]:
+        raise ValueError(f"Invalid extra_mounts entry {spec!r}: expansion introduced a ':' into a path.")
     if not dst.startswith("/"):
         # expandvars leaves an unset var verbatim, so typos land here.
         detail = f"{raw_dst!r}" if dst == raw_dst else f"{raw_dst!r} (expanded to {dst!r})"
-        raise ValueError(
-            f"Invalid extra_mounts entry {spec!r}: destination must be an absolute path, got {detail}."
-        )
+        raise ValueError(f"Invalid extra_mounts entry {spec!r}: destination must be an absolute path, got {detail}.")
     if mode not in ("ro", "rw"):
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: mode must be 'ro' or 'rw'.")
     if not Path(expanded_src).exists():

--- a/src/coder_eval/isolation/docker_runner.py
+++ b/src/coder_eval/isolation/docker_runner.py
@@ -294,17 +294,10 @@ def _validate_extra_mount(spec: str) -> str:
     write portable specs. Returns the (possibly rewritten) spec to feed
     back into argv.
 
-    The destination is expanded for the same reason the source is, and it
-    matters more than it looks: ``env_passthrough`` forwards ``HOME`` with
-    the HOST value on purpose, so a container-side path that must line up
-    with ``$HOME`` (``$HOME/.uipath`` for the uip CLI's login state, say)
-    has a different literal value on every host. Without expansion the only
-    way to write that mount is to hardcode one host's home directory, which
-    then silently mounts to the wrong place everywhere else -- and a login
-    state the CLI cannot see reads as a capability failure, not a config
-    error.
-
     Notes:
+      - Destinations are expanded too. A container path that has to match a
+        host-valued var (``$SKILLS_REPO_PATH``) would otherwise have to be
+        hardcoded per machine.
       - Mode is REQUIRED. Forgetting ``:ro`` is the single most common way
         to accidentally hand the container RW access to a host directory,
         so we make the author write it explicitly.
@@ -331,14 +324,11 @@ def _validate_extra_mount(spec: str) -> str:
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: empty source path.")
     if not raw_dst:
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: empty destination path.")
-    # Expand ~ and $VAR on BOTH sides so authors can write portable specs.
-    # Destination expansion happens BEFORE the absolute-path check, since the
-    # whole point is to let `$HOME/...` resolve to an absolute path.
+    # Expanded before the absolute-path check: that is the point.
     expanded_src = os.path.expandvars(os.path.expanduser(src))
     dst = os.path.expandvars(os.path.expanduser(raw_dst))
     if not dst.startswith("/"):
-        # An unset variable is left verbatim by expandvars, so a typo'd name
-        # lands here. Show both forms or the message is a puzzle.
+        # expandvars leaves an unset var verbatim, so typos land here.
         detail = f"{raw_dst!r}" if dst == raw_dst else f"{raw_dst!r} (expanded to {dst!r})"
         raise ValueError(
             f"Invalid extra_mounts entry {spec!r}: destination must be an absolute path, got {detail}."
@@ -350,8 +340,7 @@ def _validate_extra_mount(spec: str) -> str:
     # Reject destinations that shadow framework-owned mounts inside the
     # container. ``/work`` substrings are caught too -- /work/foo would
     # land underneath our staging dir and shadow the input/output tree.
-    # Checked on the EXPANDED destination: `$HOME` could itself expand to a
-    # reserved path, and the raw form would sail past this gate.
+    # Expanded form: a var could itself expand to a reserved path.
     dst_norm = dst.rstrip("/") or "/"
     if dst_norm in _RESERVED_MOUNT_DESTS or dst_norm.startswith(CONTAINER_WORK_DIR + "/"):
         raise ValueError(

--- a/src/coder_eval/isolation/docker_runner.py
+++ b/src/coder_eval/isolation/docker_runner.py
@@ -290,9 +290,19 @@ def _validate_extra_mount(spec: str) -> str:
 
     Defends against typos that would silently expose the host fs to the
     container, and against mount specs that shadow framework-owned mounts.
-    Normalizes the source side by expanding ``~`` and ``$VAR`` so authors
-    can write portable specs. Returns the (possibly rewritten) spec to
-    feed back into argv.
+    Normalizes BOTH sides by expanding ``~`` and ``$VAR`` so authors can
+    write portable specs. Returns the (possibly rewritten) spec to feed
+    back into argv.
+
+    The destination is expanded for the same reason the source is, and it
+    matters more than it looks: ``env_passthrough`` forwards ``HOME`` with
+    the HOST value on purpose, so a container-side path that must line up
+    with ``$HOME`` (``$HOME/.uipath`` for the uip CLI's login state, say)
+    has a different literal value on every host. Without expansion the only
+    way to write that mount is to hardcode one host's home directory, which
+    then silently mounts to the wrong place everywhere else -- and a login
+    state the CLI cannot see reads as a capability failure, not a config
+    error.
 
     Notes:
       - Mode is REQUIRED. Forgetting ``:ro`` is the single most common way
@@ -312,26 +322,36 @@ def _validate_extra_mount(spec: str) -> str:
     parts = body.split(":")
     if len(parts) < 2 or len(parts) > 3:
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: expected `src:dst[:ro|rw]`.")
-    src, dst = head + parts[0], parts[1]
+    src, raw_dst = head + parts[0], parts[1]
     # Default to read-only when mode is omitted. Mounting host paths RW
     # by default is the wrong sandbox stance: the few RW use-cases are
     # better stated explicitly than implied by silence.
     mode = parts[2] if len(parts) == 3 else "ro"
     if not src:
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: empty source path.")
-    if not dst:
+    if not raw_dst:
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: empty destination path.")
+    # Expand ~ and $VAR on BOTH sides so authors can write portable specs.
+    # Destination expansion happens BEFORE the absolute-path check, since the
+    # whole point is to let `$HOME/...` resolve to an absolute path.
+    expanded_src = os.path.expandvars(os.path.expanduser(src))
+    dst = os.path.expandvars(os.path.expanduser(raw_dst))
     if not dst.startswith("/"):
-        raise ValueError(f"Invalid extra_mounts entry {spec!r}: destination must be an absolute path.")
+        # An unset variable is left verbatim by expandvars, so a typo'd name
+        # lands here. Show both forms or the message is a puzzle.
+        detail = f"{raw_dst!r}" if dst == raw_dst else f"{raw_dst!r} (expanded to {dst!r})"
+        raise ValueError(
+            f"Invalid extra_mounts entry {spec!r}: destination must be an absolute path, got {detail}."
+        )
     if mode not in ("ro", "rw"):
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: mode must be 'ro' or 'rw'.")
-    # Expand ~ and $VAR in the source so authors can write portable specs.
-    expanded_src = os.path.expandvars(os.path.expanduser(src))
     if not Path(expanded_src).exists():
         raise ValueError(f"Invalid extra_mounts entry {spec!r}: source path does not exist on host.")
     # Reject destinations that shadow framework-owned mounts inside the
     # container. ``/work`` substrings are caught too -- /work/foo would
     # land underneath our staging dir and shadow the input/output tree.
+    # Checked on the EXPANDED destination: `$HOME` could itself expand to a
+    # reserved path, and the raw form would sail past this gate.
     dst_norm = dst.rstrip("/") or "/"
     if dst_norm in _RESERVED_MOUNT_DESTS or dst_norm.startswith(CONTAINER_WORK_DIR + "/"):
         raise ValueError(

--- a/tests/test_docker_runner_mounts.py
+++ b/tests/test_docker_runner_mounts.py
@@ -109,29 +109,24 @@ class TestValidateExtraMount:
         assert result.startswith(real_dir + ":")
 
     def test_var_expansion_in_destination(self, real_dir, monkeypatch):
-        """``$VAR`` in the destination expands too.
-
-        ``env_passthrough`` forwards ``HOME`` with the host value, so a mount
-        that has to line up with the container's ``$HOME`` would otherwise have
-        to hardcode one host's home directory.
-        """
+        """``$VAR`` in the destination expands too."""
         monkeypatch.setenv("HOME", "/home/someuser")
         result = _validate_extra_mount(f"{real_dir}:$HOME/.uipath:rw")
         assert result == f"{real_dir}:/home/someuser/.uipath:rw"
 
     def test_home_expansion_in_destination(self, real_dir, monkeypatch):
-        """``~`` in the destination expands the same way the source's does."""
+        """``~`` in the destination expands the same way the source does."""
         monkeypatch.setenv("HOME", "/home/someuser")
         result = _validate_extra_mount(f"{real_dir}:~/.uipath:ro")
         assert result == f"{real_dir}:/home/someuser/.uipath:ro"
 
     def test_unset_var_destination_rejected_with_both_forms(self, real_dir):
-        """An unset var is left verbatim, so it must fail loudly, not mount blind."""
+        """An unset var is left verbatim, so it must fail loudly."""
         with pytest.raises(ValueError, match="destination must be an absolute path"):
             _validate_extra_mount(f"{real_dir}:$NO_SUCH_VAR_HERE/x:ro")
 
     def test_destination_var_expanding_to_reserved_is_rejected(self, real_dir, monkeypatch):
-        """The shadow check runs on the EXPANDED destination, not the raw one."""
+        """The shadow check runs on the expanded destination."""
         monkeypatch.setenv("SNEAKY", "/work")
         with pytest.raises(ValueError, match="shadows a framework-owned mount"):
             _validate_extra_mount(f"{real_dir}:$SNEAKY:ro")

--- a/tests/test_docker_runner_mounts.py
+++ b/tests/test_docker_runner_mounts.py
@@ -108,6 +108,34 @@ class TestValidateExtraMount:
         result = _validate_extra_mount("$MYDIR:/mnt/x")
         assert result.startswith(real_dir + ":")
 
+    def test_var_expansion_in_destination(self, real_dir, monkeypatch):
+        """``$VAR`` in the destination expands too.
+
+        ``env_passthrough`` forwards ``HOME`` with the host value, so a mount
+        that has to line up with the container's ``$HOME`` would otherwise have
+        to hardcode one host's home directory.
+        """
+        monkeypatch.setenv("HOME", "/home/someuser")
+        result = _validate_extra_mount(f"{real_dir}:$HOME/.uipath:rw")
+        assert result == f"{real_dir}:/home/someuser/.uipath:rw"
+
+    def test_home_expansion_in_destination(self, real_dir, monkeypatch):
+        """``~`` in the destination expands the same way the source's does."""
+        monkeypatch.setenv("HOME", "/home/someuser")
+        result = _validate_extra_mount(f"{real_dir}:~/.uipath:ro")
+        assert result == f"{real_dir}:/home/someuser/.uipath:ro"
+
+    def test_unset_var_destination_rejected_with_both_forms(self, real_dir):
+        """An unset var is left verbatim, so it must fail loudly, not mount blind."""
+        with pytest.raises(ValueError, match="destination must be an absolute path"):
+            _validate_extra_mount(f"{real_dir}:$NO_SUCH_VAR_HERE/x:ro")
+
+    def test_destination_var_expanding_to_reserved_is_rejected(self, real_dir, monkeypatch):
+        """The shadow check runs on the EXPANDED destination, not the raw one."""
+        monkeypatch.setenv("SNEAKY", "/work")
+        with pytest.raises(ValueError, match="shadows a framework-owned mount"):
+            _validate_extra_mount(f"{real_dir}:$SNEAKY:ro")
+
     def test_malformed_no_colon(self):
         with pytest.raises(ValueError, match="expected `src:dst"):
             _validate_extra_mount("just-one-token")

--- a/tests/test_docker_runner_mounts.py
+++ b/tests/test_docker_runner_mounts.py
@@ -131,6 +131,18 @@ class TestValidateExtraMount:
         with pytest.raises(ValueError, match="shadows a framework-owned mount"):
             _validate_extra_mount(f"{real_dir}:$SNEAKY:ro")
 
+    def test_destination_var_carrying_a_colon_is_rejected(self, real_dir, monkeypatch):
+        """A ':' in an expanded value would add fields to the rebuilt spec."""
+        monkeypatch.setenv("SNEAKY", "/mnt/x:rw")
+        with pytest.raises(ValueError, match="introduced a ':'"):
+            _validate_extra_mount(f"{real_dir}:$SNEAKY:ro")
+
+    def test_source_var_carrying_a_colon_is_rejected(self, monkeypatch):
+        """Same guard on the source side, which is rebuilt the same way."""
+        monkeypatch.setenv("SNEAKY", "/mnt/x:rw")
+        with pytest.raises(ValueError, match="introduced a ':'"):
+            _validate_extra_mount("$SNEAKY:/mnt/y:ro")
+
     def test_malformed_no_colon(self):
         with pytest.raises(ValueError, match="expected `src:dst"):
             _validate_extra_mount("just-one-token")


### PR DESCRIPTION
## What

Expand `~` and `$VAR` on the destination side of an `extra_mounts` spec, the way the source side already is. The destination was only checked for a leading `/`.

Closes #100.

## Why

An experiment that points `plugins.path` below the repo root loses the automatic repo-root bind mount that came with it, and has to re-add the root by hand. That mount's destination has to be the host repo path: criteria shell out to `$SKILLS_REPO_PATH/tests/tasks/**/_shared/*.py`, and `SKILLS_REPO_PATH` is forwarded into the container with its host value. `DockerDriverConfig` forwards host env vars but cannot set container ones, so it cannot be pointed at a fixed path instead. Without this, the only way to write that mount is to hardcode one machine's path.

Sole consumer today is one line in `flow-v2-preview.yaml` (UiPath/skills#2728).

## Notes

- `expandvars` leaves an unset variable verbatim, so a typo'd name still fails the absolute-path check. The message shows the raw and the expanded form.
- The framework-owned-mount check runs on the expanded destination, since a variable could itself expand to `/work` or `/`.
- An expansion that injects a `:` is rejected. `SNEAKY=/mnt/x:rw` in `$src:$SNEAKY:ro` would otherwise rebuild as `/src:/mnt/x:rw:ro` and silently widen a declared read-only mount.

Six tests cover destination `$VAR`, destination `~`, the unset-variable rejection, a variable expanding to a reserved destination, and colon injection on each side.

## Verified with UiPath/skills#2728

Same spec, same shell: released 0.10.2 → `ValueError: destination must be an absolute path`; this branch → `/Users/bai.li/uipath/skills:/Users/bai.li/uipath/skills:ro`. The expanded mount reaches `docker run` and the criteria tree is readable at the host path inside the container. End to end under `flow-v2-preview.yaml`, task `uipath-maestro-flow/connector_features/path_params.yaml` on codex / `gpt-5.6-luna`: **SUCCESS, 6/6 criteria at 1.0**. Without this the experiment aborts on load, before any container starts.

One correction to #100, which changes its reasoning but not the outcome. Its problem statement says a `/.example` destination is portable "only when the forwarded `HOME` is `/`". In that container the forwarded `HOME` was `/Users/bai.li`, and `uip login status` still returned `"Status": "Logged in"` from a mount at `/.uipath`, with `.auth` present only there and not under `$HOME/.uipath`. So `uip` does not resolve its login through `HOME`, and #100's worked example is not a case this change is needed for. Its acceptance criteria are met regardless, which is why the keyword stands: a host-valued destination without an embedded username, resolved absolute, reserved destinations still rejected after expansion, expansion unable to inject fields or modes, and tests for non-root forwarded homes and unknown placeholders.
