### PR TITLE
fix(release): pin python-semantic-release + GitPython to unbreak version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,14 @@ jobs:
           fi
 
       - name: Install build + release tools
-        run: uv tool install python-semantic-release && uv tool install twine
+        # Pinned: python-semantic-release declares gitpython~=3.0, so an
+        # unpinned install can resolve GitPython 3.1.60+, which removed
+        # git.Actor.name_email_regex and breaks semantic-release's `version`
+        # command outright ("type object 'Actor' has no attribute
+        # 'name_email_regex'"). Pin both explicitly until upstream adapts.
+        run: |
+          uv tool install python-semantic-release==10.6.1 --with gitpython==3.1.59
+          uv tool install twine
 
       - name: Run semantic-release (bump + tag, no push yet)
         id: release
@@ -157,7 +164,7 @@ jobs:
           # version to pyproject.toml + __init__.py, tags it, and regenerates the
           # changelog, but does not push yet (--no-push) so we can regenerate
           # uv.lock and amend before sending.
-          PSR="uv tool run --from python-semantic-release semantic-release"
+          PSR="uv tool run --from python-semantic-release==10.6.1 --with gitpython==3.1.59 semantic-release"
           $PSR version "--$BUMP" --no-vcs-release --no-push --changelog
           # A dispatch always cuts a release; report the just-published version.
           echo "version=$($PSR version --print)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- `release.yml`'s "Run semantic-release" step was failing with `type object 'Actor' has no attribute 'name_email_regex'` (see https://github.com/UiPath/coder_eval/actions/runs/33101557604/job/98620318431).
- Root cause: `python-semantic-release` declares `gitpython~=3.0` (unbounded on patch), and GitPython 3.1.60 removed `Actor.name_email_regex`, which PSR's `version` command calls. An unpinned `uv tool install`/`uv tool run` resolved the latest (broken) GitPython.
- Fix: pin both `python-semantic-release==10.6.1` and `gitpython==3.1.59` (last GitPython release before the removal) in the two places the tool is installed/invoked.

## Test plan
- [x] `make test` — 4367 passed, 2 skipped
- [x] Verified locally: `uv tool run --from python-semantic-release==10.6.1 --with gitpython==3.1.59 semantic-release version --print` runs cleanly (no `name_email_regex` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)