### PR TITLE
chore: add @CarlesUIPath as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,11 +7,11 @@
 # dedicated GitHub team (e.g. @UiPath/coder-eval-maintainers) once one exists.
 
 # Default owners for everything in the repo.
-*       @akshaylive @tmatup @uipreliga @bai-uipath
+*       @akshaylive @tmatup @uipreliga @bai-uipath @CarlesUIPath
 
 # Community-health, license, and security files warrant extra scrutiny.
-/LICENSE            @akshaylive @tmatup @uipreliga @bai-uipath
-/NOTICE             @akshaylive @tmatup @uipreliga @bai-uipath
-/SECURITY.md        @akshaylive @tmatup @uipreliga @bai-uipath
-/CODE_OF_CONDUCT.md @akshaylive @tmatup @uipreliga @bai-uipath
-/.github/           @akshaylive @tmatup @uipreliga @bai-uipath
+/LICENSE            @akshaylive @tmatup @uipreliga @bai-uipath @CarlesUIPath
+/NOTICE             @akshaylive @tmatup @uipreliga @bai-uipath @CarlesUIPath
+/SECURITY.md        @akshaylive @tmatup @uipreliga @bai-uipath @CarlesUIPath
+/CODE_OF_CONDUCT.md @akshaylive @tmatup @uipreliga @bai-uipath @CarlesUIPath
+/.github/           @akshaylive @tmatup @uipreliga @bai-uipath @CarlesUIPath

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -118,7 +118,7 @@ jobs:
           # so this stacks on the tool allowlist below, it does not replace it.
           # Keep this list in sync with the global CODEOWNERS maintainers
           # (.github/CODEOWNERS `*` line).
-          include_comments_by_actor: "akshaylive,tmatup,uipreliga,bai-uipath"
+          include_comments_by_actor: "akshaylive,tmatup,uipreliga,bai-uipath,CarlesUIPath"
           # Drop all bot comments (dependabot, renovate, etc.). Exclusion wins
           # over the include list if an actor somehow matches both.
           exclude_comments_by_actor: "*[bot]"


### PR DESCRIPTION
## Summary

Adds `@CarlesUIPath` to every rule in `.github/CODEOWNERS` — the default `*` rule plus the community-health, license, security, and `/.github/` entries — so review is auto-requested on the same paths as the other owners.

## Note

Per the file's own comment, a code owner must have at least **Write** access to the repo or GitHub silently ignores the entry. Please confirm `@CarlesUIPath` has Write access before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011TVzuviNUJ9nQfFuhN7Fb2