### PR TITLE
fix(pricing): refresh the rate card and add gemini 3.7/3.8 Flash

### DIFF
--- a/evalboard/lib/pricing.ts
+++ b/evalboard/lib/pricing.ts
@@ -24,8 +24,8 @@ export const PRICING: Record<string, Pricing> = {
     // alias must never inherit the older tier. Undated aliases each need their
     // own key: resolvePricing's fallback only strips a trailing date (dated →
     // undated), it cannot invent one.
-    // Fable 5.1 prices cache HITS at 0.025x input ($0.25), not the 0.1x every
-    // other Claude model uses — Fable 5 pays $1 on the identical $10 base.
+    // Fable 5.1 prices cache hits at 0.025x input, not the 0.1x every other
+    // Claude model uses. Fable 5 pays $1 on the identical $10 base.
     "claude-fable-5-1": p(10, 50, 12.5, 0.25),
     "claude-fable-5": p(10, 50, 12.5, 1),
     "claude-opus-5": p(5, 25, 6.25, 0.5),
@@ -37,9 +37,7 @@ export const PRICING: Record<string, Pricing> = {
     "claude-opus-4-1": p(15, 75, 18.75, 1.5),
     "claude-opus-4": p(15, 75, 18.75, 1.5),
     "claude-opus-4-20250514": p(15, 75, 18.75, 1.5),
-    // $2/$10 is Sonnet 5's STANDARD price (the introductory rate was made
-    // permanent and the 2026-09-01 increase cancelled) — 4.6 and earlier stay
-    // at $3/$15.
+    // $2/$10, not the $3/$15 that 4.6 and earlier pay.
     "claude-sonnet-5": p(2, 10, 2.5, 0.2),
     "claude-sonnet-4-6": p(3, 15, 3.75, 0.3),
     "claude-sonnet-4-5": p(3, 15, 3.75, 0.3),
@@ -70,8 +68,7 @@ export const PRICING: Record<string, Pricing> = {
     "gpt-5.2-codex": p(1.75, 14, 1.75, 0.175),
     "gpt-5.4": p(2.5, 15, 2.5, 0.25),
     "gpt-5.5": p(5, 30, 5, 0.5),
-    // Terra and Luna repriced 2026-07-30 (-20% / -80%); Sol cut since then from
-    // $5/$30 (-20% input / -33% output). Post-cut rates.
+    // Sol's rate is promotional through at least 2026-11-21.
     "gpt-5.6-sol": p(4, 20, 4, 0.4),
     "gpt-5.6-terra": p(2, 12, 2, 0.2),
     "gpt-5.6-luna": p(0.2, 1.2, 0.2, 0.02),
@@ -82,8 +79,8 @@ export const PRICING: Record<string, Pricing> = {
     "gemini-3-pro-preview": p(2, 12, 2, 0.2),
     "gemini-3.1-pro-preview": p(2, 12, 2, 0.2),
     "gemini-3.1-pro-preview-customtools": p(2, 12, 2, 0.2),
-    // 3.6 / 3.7 / 3.8 Flash share one rate card (list rate; Google's
-    // introductory half-price window on all three runs through 2026-12-31).
+    // 3.6 / 3.7 / 3.8 Flash share one rate card. List rates; Google is
+    // discounting all three by half through 2026-12-31.
     "gemini-3.8-flash": p(1.5, 7.5, 1.5, 0.15),
     "gemini-3.7-flash": p(1.5, 7.5, 1.5, 0.15),
     "gemini-3.6-flash": p(1.5, 7.5, 1.5, 0.15),

--- a/evalboard/lib/pricing.ts
+++ b/evalboard/lib/pricing.ts
@@ -24,6 +24,9 @@ export const PRICING: Record<string, Pricing> = {
     // alias must never inherit the older tier. Undated aliases each need their
     // own key: resolvePricing's fallback only strips a trailing date (dated →
     // undated), it cannot invent one.
+    // Fable 5.1 prices cache HITS at 0.025x input ($0.25), not the 0.1x every
+    // other Claude model uses — Fable 5 pays $1 on the identical $10 base.
+    "claude-fable-5-1": p(10, 50, 12.5, 0.25),
     "claude-fable-5": p(10, 50, 12.5, 1),
     "claude-opus-5": p(5, 25, 6.25, 0.5),
     "claude-opus-4-8": p(5, 25, 6.25, 0.5),
@@ -34,7 +37,10 @@ export const PRICING: Record<string, Pricing> = {
     "claude-opus-4-1": p(15, 75, 18.75, 1.5),
     "claude-opus-4": p(15, 75, 18.75, 1.5),
     "claude-opus-4-20250514": p(15, 75, 18.75, 1.5),
-    "claude-sonnet-5": p(3, 15, 3.75, 0.3),
+    // $2/$10 is Sonnet 5's STANDARD price (the introductory rate was made
+    // permanent and the 2026-09-01 increase cancelled) — 4.6 and earlier stay
+    // at $3/$15.
+    "claude-sonnet-5": p(2, 10, 2.5, 0.2),
     "claude-sonnet-4-6": p(3, 15, 3.75, 0.3),
     "claude-sonnet-4-5": p(3, 15, 3.75, 0.3),
     "claude-sonnet-4-5-20250929": p(3, 15, 3.75, 0.3),
@@ -64,8 +70,9 @@ export const PRICING: Record<string, Pricing> = {
     "gpt-5.2-codex": p(1.75, 14, 1.75, 0.175),
     "gpt-5.4": p(2.5, 15, 2.5, 0.25),
     "gpt-5.5": p(5, 30, 5, 0.5),
-    // Terra and Luna repriced 2026-07-30 (-20% / -80%); post-cut rates.
-    "gpt-5.6-sol": p(5, 30, 5, 0.5),
+    // Terra and Luna repriced 2026-07-30 (-20% / -80%); Sol cut since then from
+    // $5/$30 (-20% input / -33% output). Post-cut rates.
+    "gpt-5.6-sol": p(4, 20, 4, 0.4),
     "gpt-5.6-terra": p(2, 12, 2, 0.2),
     "gpt-5.6-luna": p(0.2, 1.2, 0.2, 0.02),
     // Google Gemini (AntigravityAgent). Gemini bills no separate cache-write
@@ -75,6 +82,10 @@ export const PRICING: Record<string, Pricing> = {
     "gemini-3-pro-preview": p(2, 12, 2, 0.2),
     "gemini-3.1-pro-preview": p(2, 12, 2, 0.2),
     "gemini-3.1-pro-preview-customtools": p(2, 12, 2, 0.2),
+    // 3.6 / 3.7 / 3.8 Flash share one rate card (list rate; Google's
+    // introductory half-price window on all three runs through 2026-12-31).
+    "gemini-3.8-flash": p(1.5, 7.5, 1.5, 0.15),
+    "gemini-3.7-flash": p(1.5, 7.5, 1.5, 0.15),
     "gemini-3.6-flash": p(1.5, 7.5, 1.5, 0.15),
     "gemini-3.5-flash": p(1.5, 9, 1.5, 0.15),
     "gemini-3.5-flash-lite": p(0.3, 2.5, 0.3, 0.03),

--- a/src/coder_eval/pricing.py
+++ b/src/coder_eval/pricing.py
@@ -2,9 +2,15 @@
 
 Anthropic/OpenAI/Google built-in rates; plugins contribute additional rates via
 ``register_pricing()``. Prices are per million tokens (MTok).
-Sources: https://claude.com/pricing#api, https://developers.openai.com/api/docs/pricing,
-https://ai.google.dev/gemini-api/docs/pricing (all verified 2026-07-29;
-the GPT-5.6 rows re-verified 2026-08-09 after the 2026-07-30 Terra/Luna cut).
+Sources: https://platform.claude.com/docs/en/about-claude/pricing,
+https://developers.openai.com/api/docs/pricing,
+https://ai.google.dev/gemini-api/docs/pricing, and OpenRouter's live
+``/api/v1/models`` (every row re-verified 2026-09-03).
+
+The Bedrock open-weight block is the ONE exception: its eu-north-1 rates could
+not be re-verified (the AWS pricing page does not publish Stockholm figures for
+those three models), so they are carried forward unchanged rather than
+"corrected" against the US column they explicitly do not use.
 """
 
 from collections.abc import Iterable
@@ -21,9 +27,13 @@ class ModelPricing:
     cache_read_per_mtok: float  # prompt caching read
 
 
-# Official vendor rate cards, verified 2026-07-29 (GPT-5.6 rows: 2026-08-09).
+# Official vendor rate cards, verified 2026-09-03.
 # Key: CLI model name (before gateway mapping)
 _PRICING: dict[str, ModelPricing] = {
+    # Fable 5.1 (and Mythos 5.1) price cache HITS at 0.025x input, not the 0.1x
+    # every other Claude model uses — $0.25, not the $1 that Fable 5 pays on the
+    # identical $10 base. Do NOT "fix" 5.1's cache read to match 5's.
+    "claude-fable-5-1": ModelPricing(10.0, 50.0, 12.50, 0.25),
     "claude-fable-5": ModelPricing(10.0, 50.0, 12.50, 1.0),
     # Opus 4.5 and later dropped to $5/$25; 4.1 and 4 keep the old $15/$75. The
     # version boundary is the price boundary: a newer Opus is not the dearer one.
@@ -36,10 +46,13 @@ _PRICING: dict[str, ModelPricing] = {
     "claude-opus-4-1": ModelPricing(15.0, 75.0, 18.75, 1.50),
     "claude-opus-4": ModelPricing(15.0, 75.0, 18.75, 1.50),
     "claude-opus-4-20250514": ModelPricing(15.0, 75.0, 18.75, 1.50),
-    # Standard $3/$15, not the $2/$10 promo running through 2026-08-31: a static
-    # table cannot express a window, and overstating for a few weeks beats
-    # understating indefinitely after it lapses.
-    "claude-sonnet-5": ModelPricing(3.0, 15.0, 3.75, 0.30),
+    # $2/$10, NOT the $3/$15 that Sonnet 4.6 and earlier pay. The $2/$10 shipped
+    # as introductory pricing through 2026-08-31 and this table deliberately held
+    # the higher rate against it lapsing — but Anthropic has since made $2/$10 the
+    # standard price and cancelled the 2026-09-01 increase, so the hedge was
+    # simply overstating every Sonnet 5 run by 50%. Sonnet 5 is the nightly's
+    # model; do not copy the 4.x row onto it.
+    "claude-sonnet-5": ModelPricing(2.0, 10.0, 2.50, 0.20),
     "claude-sonnet-4-6": ModelPricing(3.0, 15.0, 3.75, 0.30),
     "claude-sonnet-4-5": ModelPricing(3.0, 15.0, 3.75, 0.30),
     "claude-sonnet-4-5-20250929": ModelPricing(3.0, 15.0, 3.75, 0.30),
@@ -80,12 +93,16 @@ _PRICING: dict[str, ModelPricing] = {
     "gpt-5.4-mini": ModelPricing(0.75, 4.5, 0.75, 0.075),
     "gpt-5.4-nano": ModelPricing(0.20, 1.25, 0.20, 0.02),
     # GPT-5.6: sol flagship / terra balanced (Codex default) / luna economy.
-    # Terra and Luna were REPRICED on 2026-07-30 (-20% and -80%); these are the
-    # post-cut rates. The pre-cut $2.50/$15 and $1.00/$6 are what a historical run
-    # was actually billed, but this table is a single current-rate card with no
-    # notion of an effective date — so old runs re-price low, the same tradeoff
-    # the Sonnet promo comment above already accepts.
-    "gpt-5.6-sol": ModelPricing(5.0, 30.0, 5.0, 0.50),
+    # Terra and Luna were REPRICED on 2026-07-30 (-20% and -80%), and Sol has
+    # since been cut too (-20% input / -33% output, from $5/$30); these are the
+    # post-cut rates. The pre-cut figures are what a historical run was actually
+    # billed, but this table is a single current-rate card with no notion of an
+    # effective date, so old runs re-price low.
+    # Sol's cut is published as promotional "at least through 2026-11-21" — it is
+    # taken at face value here because the one prior promo this table hedged
+    # against (Sonnet 5's $2/$10) became permanent, so pricing the CURRENT rate
+    # has the better track record. Re-check after that date.
+    "gpt-5.6-sol": ModelPricing(4.0, 20.0, 4.0, 0.40),
     "gpt-5.6-terra": ModelPricing(2.0, 12.0, 2.0, 0.20),
     "gpt-5.6-luna": ModelPricing(0.20, 1.20, 0.20, 0.02),
     # Google Gemini (AntigravityAgent, via the Gemini Developer API), keyed on the
@@ -93,6 +110,12 @@ _PRICING: dict[str, ModelPricing] = {
     # cache_write == input (unused: the agent maps cache_creation_tokens to 0).
     # CAVEAT: Pro's >200K-token tier costs more ($4/$18, $0.40 cached), so a
     # very-large-context run reads low.
+    # 3.6 / 3.7 / 3.8 Flash share one rate card. Google is running an introductory
+    # half-price window on all three through 2026-12-31 ($0.75/$3.75/$0.075); the
+    # list rate below is what they revert to, and matches what 3.6 has always been
+    # carried at here.
+    "gemini-3.8-flash": ModelPricing(1.5, 7.5, 1.5, 0.15),
+    "gemini-3.7-flash": ModelPricing(1.5, 7.5, 1.5, 0.15),
     "gemini-3.6-flash": ModelPricing(1.5, 7.5, 1.5, 0.15),
     "gemini-3.5-flash": ModelPricing(1.5, 9.0, 1.5, 0.15),
     "gemini-3.5-flash-lite": ModelPricing(0.30, 2.5, 0.30, 0.03),
@@ -113,10 +136,17 @@ _PRICING: dict[str, ModelPricing] = {
     "moonshotai.kimi-k2.5": ModelPricing(0.72, 3.6, 0.72, 0.0),
     # OpenRouter models. These providers cache prefixes implicitly (no
     # cache_control, no write fee), so cache-creation is priced at input (unused)
-    # and cache-read at OpenRouter's published input_cache_read rate.
+    # and cache-read at OpenRouter's published input_cache_read rate. Rates read
+    # from the live /api/v1/models catalogue, which is the same feed the site
+    # renders — glm-5.2 and deepseek-v4-pro had both drifted well above the
+    # figures previously carried here (deepseek's cache read by ~24x).
+    # These are headline rates: OpenRouter routes per request, so the real bill
+    # depends on the provider a call lands on. That is why the litellm path
+    # captures ACTUAL per-call cost proxy-side and overrides these (see
+    # litellm_cost.apply_actual_cost) — the rows below are the static fallback.
     "moonshotai/kimi-k3": ModelPricing(3.0, 15.0, 3.0, 0.30),
-    "z-ai/glm-5.2": ModelPricing(0.7168, 2.2528, 0.7168, 0.13312),
-    "deepseek/deepseek-v4-pro": ModelPricing(0.435, 0.87, 0.435, 0.003625),
+    "z-ai/glm-5.2": ModelPricing(0.966, 3.036, 0.966, 0.1932),
+    "deepseek/deepseek-v4-pro": ModelPricing(1.030776, 2.061552, 1.030776, 0.085898),
 }
 
 

--- a/src/coder_eval/pricing.py
+++ b/src/coder_eval/pricing.py
@@ -5,12 +5,8 @@ Anthropic/OpenAI/Google built-in rates; plugins contribute additional rates via
 Sources: https://platform.claude.com/docs/en/about-claude/pricing,
 https://developers.openai.com/api/docs/pricing,
 https://ai.google.dev/gemini-api/docs/pricing, and OpenRouter's live
-``/api/v1/models`` (every row re-verified 2026-09-03).
-
-The Bedrock open-weight block is the ONE exception: its eu-north-1 rates could
-not be re-verified (the AWS pricing page does not publish Stockholm figures for
-those three models), so they are carried forward unchanged rather than
-"corrected" against the US column they explicitly do not use.
+``/api/v1/models`` (every row re-verified 2026-09-03, except the Bedrock
+open-weight block: AWS publishes no eu-north-1 figures for those three).
 """
 
 from collections.abc import Iterable
@@ -30,9 +26,8 @@ class ModelPricing:
 # Official vendor rate cards, verified 2026-09-03.
 # Key: CLI model name (before gateway mapping)
 _PRICING: dict[str, ModelPricing] = {
-    # Fable 5.1 (and Mythos 5.1) price cache HITS at 0.025x input, not the 0.1x
-    # every other Claude model uses — $0.25, not the $1 that Fable 5 pays on the
-    # identical $10 base. Do NOT "fix" 5.1's cache read to match 5's.
+    # Fable 5.1 (and Mythos 5.1) price cache hits at 0.025x input, not the 0.1x
+    # every other Claude model uses. Fable 5 pays $1 on the identical $10 base.
     "claude-fable-5-1": ModelPricing(10.0, 50.0, 12.50, 0.25),
     "claude-fable-5": ModelPricing(10.0, 50.0, 12.50, 1.0),
     # Opus 4.5 and later dropped to $5/$25; 4.1 and 4 keep the old $15/$75. The
@@ -46,12 +41,8 @@ _PRICING: dict[str, ModelPricing] = {
     "claude-opus-4-1": ModelPricing(15.0, 75.0, 18.75, 1.50),
     "claude-opus-4": ModelPricing(15.0, 75.0, 18.75, 1.50),
     "claude-opus-4-20250514": ModelPricing(15.0, 75.0, 18.75, 1.50),
-    # $2/$10, NOT the $3/$15 that Sonnet 4.6 and earlier pay. The $2/$10 shipped
-    # as introductory pricing through 2026-08-31 and this table deliberately held
-    # the higher rate against it lapsing — but Anthropic has since made $2/$10 the
-    # standard price and cancelled the 2026-09-01 increase, so the hedge was
-    # simply overstating every Sonnet 5 run by 50%. Sonnet 5 is the nightly's
-    # model; do not copy the 4.x row onto it.
+    # $2/$10, NOT the $3/$15 that Sonnet 4.6 and earlier pay. Do not copy the
+    # 4.x row onto it.
     "claude-sonnet-5": ModelPricing(2.0, 10.0, 2.50, 0.20),
     "claude-sonnet-4-6": ModelPricing(3.0, 15.0, 3.75, 0.30),
     "claude-sonnet-4-5": ModelPricing(3.0, 15.0, 3.75, 0.30),
@@ -93,15 +84,9 @@ _PRICING: dict[str, ModelPricing] = {
     "gpt-5.4-mini": ModelPricing(0.75, 4.5, 0.75, 0.075),
     "gpt-5.4-nano": ModelPricing(0.20, 1.25, 0.20, 0.02),
     # GPT-5.6: sol flagship / terra balanced (Codex default) / luna economy.
-    # Terra and Luna were REPRICED on 2026-07-30 (-20% and -80%), and Sol has
-    # since been cut too (-20% input / -33% output, from $5/$30); these are the
-    # post-cut rates. The pre-cut figures are what a historical run was actually
-    # billed, but this table is a single current-rate card with no notion of an
-    # effective date, so old runs re-price low.
-    # Sol's cut is published as promotional "at least through 2026-11-21" — it is
-    # taken at face value here because the one prior promo this table hedged
-    # against (Sonnet 5's $2/$10) became permanent, so pricing the CURRENT rate
-    # has the better track record. Re-check after that date.
+    # This table is a single current-rate card with no notion of an effective
+    # date, so a repriced model makes historical runs re-price at today's rate.
+    # Sol's rate is promotional through at least 2026-11-21; re-check then.
     "gpt-5.6-sol": ModelPricing(4.0, 20.0, 4.0, 0.40),
     "gpt-5.6-terra": ModelPricing(2.0, 12.0, 2.0, 0.20),
     "gpt-5.6-luna": ModelPricing(0.20, 1.20, 0.20, 0.02),
@@ -110,10 +95,8 @@ _PRICING: dict[str, ModelPricing] = {
     # cache_write == input (unused: the agent maps cache_creation_tokens to 0).
     # CAVEAT: Pro's >200K-token tier costs more ($4/$18, $0.40 cached), so a
     # very-large-context run reads low.
-    # 3.6 / 3.7 / 3.8 Flash share one rate card. Google is running an introductory
-    # half-price window on all three through 2026-12-31 ($0.75/$3.75/$0.075); the
-    # list rate below is what they revert to, and matches what 3.6 has always been
-    # carried at here.
+    # 3.6 / 3.7 / 3.8 Flash share one rate card. These are list rates; Google is
+    # discounting all three by half through 2026-12-31.
     "gemini-3.8-flash": ModelPricing(1.5, 7.5, 1.5, 0.15),
     "gemini-3.7-flash": ModelPricing(1.5, 7.5, 1.5, 0.15),
     "gemini-3.6-flash": ModelPricing(1.5, 7.5, 1.5, 0.15),
@@ -136,14 +119,11 @@ _PRICING: dict[str, ModelPricing] = {
     "moonshotai.kimi-k2.5": ModelPricing(0.72, 3.6, 0.72, 0.0),
     # OpenRouter models. These providers cache prefixes implicitly (no
     # cache_control, no write fee), so cache-creation is priced at input (unused)
-    # and cache-read at OpenRouter's published input_cache_read rate. Rates read
-    # from the live /api/v1/models catalogue, which is the same feed the site
-    # renders — glm-5.2 and deepseek-v4-pro had both drifted well above the
-    # figures previously carried here (deepseek's cache read by ~24x).
-    # These are headline rates: OpenRouter routes per request, so the real bill
-    # depends on the provider a call lands on. That is why the litellm path
-    # captures ACTUAL per-call cost proxy-side and overrides these (see
-    # litellm_cost.apply_actual_cost) — the rows below are the static fallback.
+    # and cache-read at OpenRouter's published input_cache_read rate, read from
+    # the live /api/v1/models catalogue. Headline rates only: OpenRouter routes
+    # per request, so the real bill depends on the provider a call lands on —
+    # which is why the litellm path captures actual per-call cost proxy-side and
+    # overrides these (litellm_cost.apply_actual_cost). Static fallback.
     "moonshotai/kimi-k3": ModelPricing(3.0, 15.0, 3.0, 0.30),
     "z-ai/glm-5.2": ModelPricing(0.966, 3.036, 0.966, 0.1932),
     "deepseek/deepseek-v4-pro": ModelPricing(1.030776, 2.061552, 1.030776, 0.085898),

--- a/tests/test_antigravity_agent.py
+++ b/tests/test_antigravity_agent.py
@@ -213,6 +213,8 @@ def test_tool_name_map_covers_core_builtins():
         "gemini-3.1-pro-preview",
         "gemini-3.1-pro-preview-customtools",
         "gemini-3-pro-preview",
+        "gemini-3.8-flash",
+        "gemini-3.7-flash",
         "gemini-3.6-flash",
         "gemini-3.5-flash",
         "gemini-3.5-flash-lite",

--- a/tests/test_cost_accounting_paths.py
+++ b/tests/test_cost_accounting_paths.py
@@ -259,7 +259,7 @@ class TestRowCostProjection:
         """UserSimulator pins model=None, so it bills at BEDROCK_MODEL.
 
         A task that pins ``agent.model`` would otherwise mis-bill every simulated
-        row. Here the subject is sonnet-5 ($3/$15) while the route is haiku-4.5
+        row. Here the subject is sonnet-5 ($2/$10) while the route is haiku-4.5
         ($1/$5), so the simulator must cost the haiku rate.
         """
         result = self._simulated(bedrock_model="claude-haiku-4-5-20251001")
@@ -269,8 +269,8 @@ class TestRowCostProjection:
     def test_simulator_falls_back_to_the_subject_model_off_bedrock(self):
         """A non-Bedrock route names no model on the record; the subject's is the best available."""
         result = self._simulated()
-        # sonnet-5 at $3/$15 per MTok.
-        assert eval_result_to_task_dict(result)["simulator_cost_usd"] == pytest.approx(3.0 + 1.5)
+        # sonnet-5 at $2/$10 per MTok: 1M uncached input + 100K output.
+        assert eval_result_to_task_dict(result)["simulator_cost_usd"] == pytest.approx(2.0 + 1.0)
 
     def test_single_shot_row_has_no_simulator_cost(self):
         result = _result([_turn(1, TokenUsage(uncached_input_tokens=10, output_tokens=1, total_cost_usd=0.1))])


### PR DESCRIPTION
Re-verified every row of the built-in rate card against the vendor cards, and added the models the antigravity bump now needs. Four rows were stale; three models were missing entirely.

## Why now

`ANTIGRAVITY_MODEL` was just moved to `gemini-3.8-flash` in both variable stores (the `skills` repo variable and the ADO `coder-eval-athena-config` group). Antigravity computes cost locally from tokens against this table, so an unpriced id books no cost at all — the run still passes, but reports `cost_complete: false` and a null bill. That prompted a full audit rather than just the one row.

## Repriced

| model | was | now |
|---|---|---|
| `claude-sonnet-5` | $3 / $15 | **$2 / $10** |
| `gpt-5.6-sol` | $5 / $30 | **$4 / $20** |
| `z-ai/glm-5.2` | 0.7168 / 2.2528 | **0.966 / 3.036** |
| `deepseek/deepseek-v4-pro` | 0.435 / 0.87 | **1.0308 / 2.0616** |

`claude-sonnet-5` is the significant one. The table deliberately held $3/$15 against the $2/$10 introductory rate lapsing on 2026-08-31. Anthropic has since made $2/$10 the standard price and cancelled the scheduled increase, so that hedge was overstating every run of the nightly's own model by 50%.

The two OpenRouter rows come from the live `/api/v1/models` feed. Both had drifted up, and `deepseek-v4-pro`'s cache-read rate was low by roughly 24x.

## Added

- `gemini-3.8-flash` and `gemini-3.7-flash` — same list rate as 3.6.
- `claude-fable-5-1` — it prices cache hits at 0.025x input, not the 0.1x every other Claude model uses. Worth a row of its own so nobody copies Fable 5's figure onto it.

## Left alone, deliberately

The three Bedrock open-weight rows (`deepseek.v3.2`, `zai.glm-5`, `moonshotai.kimi-k2.5`) are unchanged. AWS does not publish eu-north-1 figures for them, and the existing comment warns against substituting the US column. Carried forward and documented rather than guessed.

## Verification

Full Python suite, evalboard `tsc --noEmit`, and all 608 evalboard tests pass, including the `pricing.py` ↔ `pricing.ts` parity guard. The 13 failures in `test_judge_litellm.py` / `test_reports_stats_nonfinite.py` on my machine reproduce identically with these changes stashed — a local venv artifact, not this branch.

The gemini rows were confirmed end to end: an antigravity run on `gemini-3.8-flash` went from `cost_complete: false` / null cost to `cost_complete: true` / \$0.0685 once the row was present.